### PR TITLE
checkIfRouteIsTrackable() requires first and second segment in url

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -209,7 +209,7 @@ class UrlGenerator extends BaseUrlGenerator
      */
     protected function checkIfRouteIsTrackable(): bool
     {
-        return in_array( request()->segment(1), config('localized-routes.traced_sources') );
+        return in_array(request()->segment(1), config('localized-routes.traced_sources')) && request()->segment(2) !== null;
     }
 
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -209,7 +209,7 @@ class UrlGenerator extends BaseUrlGenerator
      */
     protected function checkIfRouteIsTrackable(): bool
     {
-        return in_array(request()->segment(1), config('localized-routes.traced_sources')) && request()->segment(2) !== null;
+        return in_array(request()->segment(1), config('localized-routes.traced_sources', [])) && request()->segment(2) !== null;
     }
 
 

--- a/src/LocalizedUrlGenerator.php
+++ b/src/LocalizedUrlGenerator.php
@@ -393,6 +393,6 @@ class LocalizedUrlGenerator
      */
     protected function checkIfRouteIsTrackable( $slugs ): bool
     {
-        return in_array( $slugs[0], config('localized-routes.traced_sources') );
+        return in_array($slugs[0], config('localized-routes.traced_sources', [])) && isset($slugs[1]);
     }
 }


### PR DESCRIPTION
[checkIfRouteIsTrackable() requires first and second segment in url](https://github.com/gutanas/laravel-localized-routes/commit/782952436f2c59804a073f72ea7ae7157ff349ad)

[checkIfRouteIsTrackable() requires first and second segment in url](https://github.com/gutanas/laravel-localized-routes/commit/c684f06fe7238e816234b663a456b5c48f4ad622)

[Added default value for in_array()](https://github.com/gutanas/laravel-localized-routes/commit/001f925d471e61adc5730ec6b744efdf4521ab03)